### PR TITLE
記事に関するAPIのルーティングの実装

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  namespace 'api' do
-    namespace 'v1' do
+  namespace "api" do
+    namespace "v1" do
       mount_devise_token_auth_for "User", at: "auth"
       resources :articles
     end
   end
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace 'api' do
+    namespace 'v1' do
+      mount_devise_token_auth_for "User", at: "auth"
+      resources :articles
+    end
+  end
+
 end


### PR DESCRIPTION
## 概要
- タイトルの通り

## 内容
- endpoint が `/api/v1` から始まるように設定

## 実行したコマンド
- endpoint を設定後、`bundle exec rails routes|grep articles` で設定を確認