### PR TITLE
記事一覧の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 
 # 追加
 gem "active_model_serializers", "~> 0.10.0"
+gem "active_model_serializers", "~> 0.10.0"
 gem "devise_token_auth"
 
 group :development, :test do

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,21 @@
+module Api::V1
+  class ArticlesController < BaseApiController # base_api_controller を継承
+    def index
+      # articles = Article.all
+
+      articles = Article.order(updated_at: :desc)
+
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = Article.find(params[:id])
+
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+
+
+
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -19,8 +19,8 @@
 #
 FactoryBot.define do
   factory :article do
-    title { Faker::Book.title }
-    body { "MyText" }
-    user { nil }
+    title { Faker::Lorem.word }
+    body { Faker::Lorem.sentence }
+    user
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+
+    let!(:article1) { create(:article) }
+    let!(:article2) { create(:article) }
+    let!(:article3) { create(:article) }
+
+    it "記事の一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+    end
+  end
+
+  # describe "GET /articles/:id" do
+  #   subject { get(api_v1_articles_path(article_id)) }
+
+  #   context "指定した id の記事が存在するとき" do
+  #     let(:article) { create(:article) }
+  #     let(:article_id) { article.id }
+
+  #     it "指定した id の記事を取得できる" do
+  #       subject
+  #       res = JSON.parse(response.body)
+  #       expect(response).to have_http_status(200)
+  #       expect(res[0]["id"]).to eq article.id
+  #       expect(res[0]["title"]).to eq article.title
+  #       expect(res[0]["body"]).to eq article.body
+  #       expect(res[0]["updated_at"]).to be_present
+  #       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+  #     end
+  #   end
+
+  #   # context "指定した id の記事が存在しないとき" do
+  #   #   let(:article_id) { 10000 }
+
+  #   #   fit "記事が見つからない" do
+  #   #     expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+  #   #   end
+  #   # end
+  # end
+end


### PR DESCRIPTION
## 概要
- タイトルの通り

## 内容
- active_model_serializers を導入
- article_preview_serializer.rb の作成(serializer ファイル)
- articles_controller.rb の作成
- articles_controller.rb の作成
- request のテストの実装

## 実行したコマンド
- active_model_serializers を導入
  `bundle install`