### PR TITLE
 記事作成の実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,10 @@ Layout/IndentationConsistency:
    Exclude:
     - 'spec/**/*'
 
+RSpec/AnyInstance:
+   Exclude:
+    - 'spec/**/*'
+
 AllCops:
   TargetRubyVersion: 2.7
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -14,5 +14,17 @@ module Api::V1
 
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
+
+    def create
+      @article = current_user.articles.create!(article_params)
+
+      render json: @article, serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    private
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
+  # current_user を定義し、仮実装として「users テーブルの一番初めのユーザー」を引用
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -46,4 +46,23 @@ RSpec.describe "Api::V1::Articles", type: :request do
     #   end
     # end
   end
+
+  describe "POST/articles/" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    let(:params) { { article: attributes_for(:article) } }
+    # current_user をテストのときだけ別の値として参照する
+    let(:current_user) { create(:user) }
+
+    # stub
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    it "記事を作成できる" do
+      expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+      res = JSON.parse(response.body)
+      expect(res["title"]).to eq params[:article][:title]
+      expect(res["body"]).to eq params[:article][:body]
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- タイトルの通り

## 内容
- ダミーの `current_user`メソッドを定義
- create アクションを作成
- テストにスタブを定義