### PR TITLE
新規登録 API 実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,10 @@ RSpec/AnyInstance:
    Exclude:
     - 'spec/**/*'
 
+Style/CommentedKeyword:
+   Exclude:
+    - 'spec/**/*'
+
 AllCops:
   TargetRubyVersion: 2.7
 

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -8,7 +8,6 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
 
     def account_update_params #更新用のメソッド
       params.permit(:name, :email)
-
     end
 
 end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,11 +1,13 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
   private
 
-    def sign_up_params # 新規登録用のメソッド
+    # 新規登録用のメソッド
+    def sign_up_params
       params.permit(:name, :email, :password, :password_confirmation)
     end
 
-    def account_update_params # 更新用のメソッド
+    # 更新用のメソッド
+    def account_update_params
       params.permit(:name, :email)
     end
 end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,13 +1,11 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-
   private
 
-    def sign_up_params #新規登録用のメソッド
+    def sign_up_params # 新規登録用のメソッド
       params.permit(:name, :email, :password, :password_confirmation)
     end
 
-    def account_update_params #更新用のメソッド
+    def account_update_params # 更新用のメソッド
       params.permit(:name, :email)
     end
-
 end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+
+  private
+
+    def sign_up_params #新規登録用のメソッド
+      params.permit(:name, :email, :password, :password_confirmation)
+    end
+
+    def account_update_params #更新用のメソッド
+      params.permit(:name, :email)
+
+    end
+
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,6 @@ module WonderfulEditor
                        request_specs: true
     end
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = {:'access-token' => 'access-token',
+                          :'client' => 'client',
+                          :'expiry' => 'expiry',
+                          :'uid' => 'uid',
+                          :'token-type' => 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = {:'access-token' => 'access-token',
-                          :'client' => 'client',
-                          :'expiry' => 'expiry',
-                          :'uid' => 'uid',
-                          :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                           'client': "client",
+                           'expiry': "expiry",
+                           'uid': "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
-        registrations: "api/v1/auth/registrations"
+        registrations: "api/v1/auth/registrations",
       }
       resources :articles
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,13 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "home#index"
 
-  namespace "api" do
-    namespace "v1" do
-      mount_devise_token_auth_for "User", at: "auth"
+  get "/api/v1/auth" , to: "api/v1/auth/registrations#sign_up_params"
+
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations"
+      }
       resources :articles
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 Rails.application.routes.draw do
   root to: "home#index"
 
-  get "/api/v1/auth" , to: "api/v1/auth/registrations#sign_up_params"
-
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  image                  :string
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     name { Faker::Name.name }

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "GET /index" do

--- a/spec/requests/v1/auth/registrations_spec.rb
+++ b/spec/requests/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/v1/auth/registrations_spec.rb
+++ b/spec/requests/v1/auth/registrations_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "V1::Auth::Registrations", type: :request do
   describe "GET /index" do


### PR DESCRIPTION
## 概要
- タイトル通り

## 内容
- `/api/v1/auth`配下に `registrations_controller.rb` を作成
-  `registrations_controller.rb` に**新規登録**と**更新**のメソッドを追加
- config/initializers/device_token_auth.rb の設定
- config/routes.rb の設定
- 422 Erorr と CSRF 対策

## 実行したコマンド
- `/api/v1/auth`配下に `registrations_controller.rb` を作成
  ○ `rails g controller api/v1/auth/registrations`