### PR TITLE
既存APIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,9 +1,9 @@
 module Api::V1
   # base_api_controller を継承
   class ArticlesController < BaseApiController
-    def index
-      # articles = Article.all
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
 
+    def index
       articles = Article.order(updated_at: :desc)
 
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
- alias_method :current_user, :current_api_v1_user
- alias_method :authenticate_user!, :authenticate_api_v1_user!
- alias_method :user_signed_in?, :api_v1_user_signed_in?
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  # current_user を定義し、仮実装として「users テーブルの一番初めのユーザー」を引用
-  def current_user
-    @current_user ||= User.first
-  end
+ alias_method :current_user, :current_api_v1_user
+ alias_method :authenticate_user!, :authenticate_api_v1_user!
+ alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -20,13 +20,12 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  # context "タイトルを指定しているとき" do
-  #   let(:article) { build(:article) }
-  #   it "記事を作成できる" do
-  #     expect(article).to be_valid
-  #   end
-  #   # pending "add some examples to (or delete) #{__FILE__}"
-  # end
+  context "タイトルを指定しているとき" do
+    let(:article) { build(:article) }
+    it "記事を作成できる" do
+      expect(article).to be_valid
+    end
+  end
 
   context "タイトルを指定していないとき" do
     let(:article) { build(:article, title: nil) }

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
       let(:user) { create(:user) }
       let!(:headers) { { "access-token" => "", "token-type" => "", "client" => "", "expiry" => "", "uid" => "" } }
 
-      fit "ログアウトできない" do
+      it "ログアウトできない" do
         subject
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:not_found)

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -37,25 +37,16 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect(res[0]["user"].keys).to eq ["id", "name", "email"]
       end
     end
-
-    # context "指定した id の記事が存在しないとき" do
-    #   let(:article_id) { 10000 }
-
-    #   fit "記事が見つからない" do
-    #     expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
-    #   end
-    # end
   end
 
   describe "POST/articles/" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     # current_user をテストのときだけ別の値として参照する
     let(:current_user) { create(:user) }
 
-    # stub
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     it "記事を作成できる" do
       expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
@@ -67,16 +58,16 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params,headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:article) { create(:article, user: current_user) }
     # current_user をテストのときだけ別の値として参照する
     let(:current_user) { create(:user) }
     # stub
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
-    it "記事のレコードを更新をできる" do
+    fit "記事のレコードを更新をできる" do
       expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
                             change { article.reload.body }.from(article.body).to(params[:article][:body])
       expect(response).to have_http_status(:ok)
@@ -84,13 +75,13 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id),headers: headers) }
 
     let(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
-    it "記事のレコードを削除できる" do
+    fit "記事のレコードを削除できる" do
       expect { subject }.to change { Article.count }.by(0)
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params,headers: headers) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:article) { create(:article, user: current_user) }
@@ -67,7 +67,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     # stub
     let(:headers) { current_user.create_new_auth_token }
 
-    fit "記事のレコードを更新をできる" do
+    it "記事のレコードを更新をできる" do
       expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
                             change { article.reload.body }.from(article.body).to(params[:article][:body])
       expect(response).to have_http_status(:ok)
@@ -75,13 +75,13 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article.id),headers: headers) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
-    fit "記事のレコードを削除できる" do
+    it "記事のレコードを削除できる" do
       expect { subject }.to change { Article.count }.by(0)
       expect(response).to have_http_status(:ok)
     end


### PR DESCRIPTION
## 概要
- **base_api_controller** で **devise_token_auth** で提供されている各種メソッドを使用できるように修正
- テストの修正

## 内容
- api_controller のダミーコードである current_user メソッド を削除
- **base_api_controller** で **devise_token_auth** で以下のメソッドを使えるように設定
　○ current_user　
　○ authenticate_user!
　○ user_signed_in?
- ログインしていないと使えない API (create,update,destroy) は authenticate_user! で弾くように実装
- テストでログインが必要な API を叩く際に headers を渡すように実装