### PR TITLE
Article model に下書き機能を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default(NULL), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -23,4 +24,6 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+
+  enum status: { draft: "draft", published: "published" }
 end

--- a/db/migrate/20220405094443_add_status_to_articles.rb
+++ b/db/migrate/20220405094443_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_05_183238) do
+ActiveRecord::Schema.define(version: 2022_04_05_094443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2022_03_05_183238) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default(NULL), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -22,5 +23,13 @@ FactoryBot.define do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
     user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default(NULL), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -31,6 +32,24 @@ RSpec.describe Article, type: :model do
     let(:article) { build(:article, title: nil) }
     it "エラーする" do
       expect(article).not_to be_valid
+    end
+  end
+
+  context "status が下書き状態のとき" do
+    let(:article) { build(:article, :draft) }
+
+    it "記事を下書き状態で作成できる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "draft"
+    end
+  end
+
+  context "status が公開状態のとき" do
+    let(:article) { build(:article, :published) }
+
+    it "記事を公開状態で作成できる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "published"
     end
   end
 end


### PR DESCRIPTION
## 概要
- 下書き機能とステータス(公開・非公開)を追加

## 内容
- **aricle_model.rb** に `enum` を追加
- データベーススキーマに `status` カラムを追加
- ストロングパラメーターに `status` を追加
- テストの実装
- spec/factories/`articles.rb` に trait を設定

## 実行したコマンド
- データベーススキーマに `status` カラムを追加
   ○ `rails generate migration AddStatusToArticles status:string `
   ○ `bundle exec rails db:migrate`
