### PR TITLE
既存のAPIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,21 +4,21 @@ module Api::V1
     before_action :authenticate_user!, only: [:create, :update, :destroy]
 
     def index
-      articles = Article.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
 
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      articles = Article.find(params[:id])
+      article = Article.published.find(params[:id])
 
-      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+      render json: article, each_serializer: Api::V1::ArticleSerializer
     end
 
     def create
-      @article = current_user.articles.create!(article_params)
+      article = current_user.articles.create!(article_params)
 
-      render json: @article, serializer: Api::V1::ArticlePreviewSerializer
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     def update
@@ -26,21 +26,19 @@ module Api::V1
 
       article.update!(article_params)
 
-      render json: article, serializer: Api::V1::ArticlePreviewSerializer
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     def destroy
       article = current_user.articles.find(params[:id])
 
       article.destroy!
-
-      render json: article, serializer: Api::V1::ArticlePreviewSerializer
     end
 
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
-#  status     :integer          default(NULL), not null
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,5 +1,4 @@
-class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+class Api::V1::ArticleSerializer < ActiveModel::Serializer
   attributes :id, :title, :body, :status, :updated_at
-
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2022_04_05_094443) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "status", default: 0, null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
-#  status     :integer          default(NULL), not null
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
-#  status     :integer          default(NULL), not null
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -4,37 +4,57 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { create(:article) }
-    let!(:article2) { create(:article) }
-    let!(:article3) { create(:article) }
+    let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :published, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article, :published) }
 
-    it "記事の一覧が取得できる" do
+    before { create(:article, :draft) }
+
+    it "公開している記事の一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
 
       expect(response).to have_http_status(:ok)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "user"]
+      expect(res[0].keys).to eq ["id", "title", "body", "status", "updated_at", "user"]
       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
     end
   end
 
   describe "GET /articles/:id" do
-    subject { get(api_v1_articles_path(article_id)) }
+    subject { get(api_v1_article_path(article_id)) }
 
-    context "指定した id の記事が存在するとき" do
-      let(:article) { create(:article) }
+    context "指定した id の記事が公開されているとき" do
       let(:article_id) { article.id }
+      let(:article) { create(:article, :published) }
 
       it "指定した id の記事を取得できる" do
         subject
         res = JSON.parse(response.body)
+
         expect(response).to have_http_status(:ok)
-        expect(res[0]["id"]).to eq article.id
-        expect(res[0]["title"]).to eq article.title
-        expect(res[0]["body"]).to eq article.body
-        expect(res[0]["updated_at"]).to be_present
-        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+        expect(res["id"]).to eq article.id
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["updated_at"]).to be_present
+        expect(res["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+
+    context "指定した id の記事が下書きのとき" do
+      let(:article_id) { article.id }
+      let(:article) { create(:article, :draft) }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "指定した id の記事が存在しない場合" do
+      let(:article_id) { 10000 }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     it "記事のレコードを削除できる" do
       expect { subject }.to change { Article.count }.by(0)
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:no_content)
     end
   end
 end


### PR DESCRIPTION
## 概要
- タイトル通り

## 内容
- 公開されている記事だけ取得できるよう実装
- 記事を作成する場合、記事の公開/非公開を選択できるよう実装
- 修正箇所のテストを修正