### PR TITLE
自分が書いた記事一覧の取得

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  class Current::ArticlesController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.published.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
+      namespace :current do
+        resources :articles, only: [:index]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe "Api::V1::Currrent::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) }
+
+    context "自分の書いた公開記事が存在するとき" do
+      let!(:article1) { create(:article, :published, user: current_user, updated_at: 1.day.ago) }
+      let!(:article2) { create(:article, :published, user: current_user, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article, :published, user: current_user) }
+
+      before do
+        create(:article, :draft, user: current_user)
+        create(:article, :published)
+      end
+
+      fit "自分の書いた公開記事を取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+  end
+end

--- a/spec/requests/v1/auth/registrations_spec.rb
+++ b/spec/requests/v1/auth/registrations_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "V1::Auth::Registrations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end


### PR DESCRIPTION
## 概要
- マイページ作成

## 内容
- 作成したマイページには、自分の書いた公開記事を取得するよう実装
- routing  の設定
- テストの実装

## 実行したコマンド
- 作成したマイページには、自分の書いた公開記事を取得するよう実装
   - `bundle exec rails g controller api/v1/current/articles`